### PR TITLE
Fix collection complete zip duplicate filename

### DIFF
--- a/Products/RhaptosCollection/types/Collection.py
+++ b/Products/RhaptosCollection/types/Collection.py
@@ -1278,6 +1278,10 @@ class Collection(CollectionBase, CollaborationManager):
                         continue
                     if module_file == 'CVS':
                         continue
+                    if module_file == 'index_auto_generated.cnxml':
+                        # this is already included in the "Handle CNXML version
+                        # upgrade/metadata extension" code above
+                        continue
 
                     module_file_name = module_file
                     bytes = str(module.getFile(module_file_name))


### PR DESCRIPTION
Collection complete zips sometimes have duplicate
index_auto_generated.cnxml which causes unzip to fail.  For example, on
prod, when unzipping col11790 1.1 complete.zip:

```
replace col11790_1.1_complete/m42119/index_auto_generated.cnxml? [y]es, [n]o, [A]ll, [N]one, [r]ename:
```

There are 2 col11790_1.1_complete/m42119/index_auto_generated.cnxml in
the zip file.

The reason is in `Collection.addModuleFiles`, we explicitly create a
index_auto_generated.cnxml file and add it to the zip file and then
later on, we add all the module files which include another
index_auto_generated.cnxml.

The fix is to skip the index_auto_generated.cnxml when adding all the
module files to the complete zip file.