### PR TITLE
Build zips even if collection is locked 

### DIFF
--- a/Products/RhaptosCollection/types/Collection.py
+++ b/Products/RhaptosCollection/types/Collection.py
@@ -1126,11 +1126,10 @@ class Collection(CollectionBase, CollaborationManager):
 
         # ...complete collxml package generation
         if rebuildCompleteZip:
-            if status != 'locked':
-                key = "colcomplete_%s" % self.objectId
-                dictRequest = {'id':oid, 'version':ver, 'repository':repos, 'serverURL':self.REQUEST['SERVER_URL']}
-                qtool.add(key, dictRequest, "%s/create_collection_complete_export_zip.zctl" % script_location)
-                added.append('colcomplete')
+            key = "colcomplete_%s" % self.objectId
+            dictRequest = {'id':oid, 'version':ver, 'repository':repos, 'serverURL':self.REQUEST['SERVER_URL']}
+            qtool.add(key, dictRequest, "%s/create_collection_complete_export_zip.zctl" % script_location)
+            added.append('colcomplete')
 
         # ...pdf and latex generation
         if rebuildCollectionPDF:


### PR DESCRIPTION
We're having workflow issues with books being published in a locked state. This would allow the zip to be rebuilt in any case. This is a possible solution, though it means we'll be building zips that don't match the PDF we're serving.