### PR TITLE
when updating latest object, only create latest version

### DIFF
--- a/Products/RhaptosCollection/types/Collection.py
+++ b/Products/RhaptosCollection/types/Collection.py
@@ -582,8 +582,7 @@ class Collection(CollectionBase, CollaborationManager):
                                                     version=db_history[0]['version']
                                                     ).dictionaries()[0]
 
-                for item in db_history:
-                    versionFolder[item['version']]  # Triggers db lookup and creation
+                versionFolder[latest['version']]  # Triggers db lookup and creation
                 versionFolder.latest.edit(latest['name'], latest['version'])
                 self.catalog.catalog_object(versionFolder.latest)
                 self.REQUEST.RESPONSE.redirect(versionFolder.url(), status=301)


### PR DESCRIPTION
Not all versions of all collections have correct DB representation - also, it's a _rare_ case that more than one version would be missing from the ZODB, and that can be worked around by visiting each version-specific URL, in any case.