### PR TITLE
Add CC-by-nc-sa 4.0 license to list of allowed licenses

### DIFF
--- a/Products/RhaptosCollection/config.py
+++ b/Products/RhaptosCollection/config.py
@@ -21,6 +21,7 @@ GLOBALS = globals()
 WORKSPACE_TYPES = ("Workgroup", "Workspace")
 
 LICENSES = DisplayList((
+    ('http://creativecommons.org/licenses/by-nc-sa/4.0/', 'Creative Commons Attribution-NonCommercial-ShareAlike License 4.0'),
     ('http://creativecommons.org/licenses/by/4.0/', 'Creative Commons Attribution 4.0'),
     ('http://creativecommons.org/licenses/by/3.0/', 'Creative Commons Attribution 3.0'),
     ('http://creativecommons.org/licenses/by/2.0/', 'Creative Commons Attribution 2.0'),


### PR DESCRIPTION
This is currently blocking the use of the collection_metadata editing page for Calculus and its derived copies.